### PR TITLE
Change sketching of read to match refseq sketch

### DIFF
--- a/doc/sphinx/tutorials.rst
+++ b/doc/sphinx/tutorials.rst
@@ -79,7 +79,7 @@ by ignoring single-copy k-mers, which are more likely to be erroneous:
 
 .. code::
 
-  mash sketch -m 2 reads.fastq
+  mash sketch -m 2 -k 16 -s 400 reads.fastq
 
 Run :code:`mash dist` with the RefSeq archive as the reference and the read
 sketch as the query:


### PR DESCRIPTION
I ran through this tutorial and I got a warning and an error about the K size of the reads (21) vs the K size of reqseq (16). I also got a warning about the sketch size. I've added a change to the docs which appears to match the precomputed refseq sketch.