### PR TITLE
fix null-pointer deref on sequences without comment

### DIFF
--- a/src/mash/Sketch.cpp
+++ b/src/mash/Sketch.cpp
@@ -1176,13 +1176,13 @@ Sketch::SketchOutput * sketchFile(Sketch::SketchInput * input)
 			if ( input->fileName == "-" )
 			{
 				reference.name = seq->name.s;
-				reference.comment = seq->comment.s;
+				reference.comment = seq->comment.s ? seq->comment.s : "";
 			}
 			else
 			{
 				reference.comment = seq->name.s;
 				reference.comment.append(" ");
-				reference.comment.append(seq->comment.s);
+				reference.comment.append(seq->comment.s ? seq->comment.s : "");
 			}
 		}
 		


### PR DESCRIPTION
mash segfaults during sketching when the sequence in question does not have a FASTA comment. Adding a simple check fixes that.