### PR TITLE
mash: abort if mmap fails to map the file

### DIFF
--- a/src/mash/Sketch.cpp
+++ b/src/mash/Sketch.cpp
@@ -257,6 +257,14 @@ uint64_t Sketch::initParametersFromCapnp(const char * file)
     
     void * data = mmap(NULL, fileInfo.st_size, PROT_READ, MAP_PRIVATE, fd, 0);
     
+    if (data == MAP_FAILED)
+    {
+        uint64_t fileSize = fileInfo.st_size;
+        std::cerr << "Error: could not memory-map file " << file << " of size " << fileSize;
+        std::cerr << std::endl;
+        exit(1);
+    }
+
     capnp::ReaderOptions readerOptions;
     
     readerOptions.traversalLimitInWords = 1000000000000;


### PR DESCRIPTION
This fixes this invalid memory read (with valgrind memcheck):

==18951== Invalid read of size 4
==18951==    at 0x45C77C: capnp::FlatArrayMessageReader::FlatArrayMessageReader(kj::ArrayPtr<capnp::word const>, capnp::ReaderOptions) (in /home/boisver1/mash-Linux64-v2.0/mash)
==18951==    by 0x4302F8: loadCapnp(Sketch::SketchInput*) (in /home/boisver1/mash-Linux64-v2.0/mash)
==18951==    by 0x434F7F: ThreadPool<Sketch::SketchInput, Sketch::SketchOutput>::thread(void*) (in /home/boisver1/mash-Linux64-v2.0/mash)
==18951==    by 0x5053E24: start_thread (in /usr/lib64/libpthread-2.17.so)
==18951==    by 0x587834C: clone (in /usr/lib64/libc-2.17.so)
==18951==  Address 0xffffffffffffffff is not stack'd, malloc'd or (recently) free'd