### PR TITLE
Add command taxscreen to create taxonomic report

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -15,6 +15,7 @@ SOURCES=\
 	src/mash/CommandBounds.cpp \
 	src/mash/CommandContain.cpp \
 	src/mash/CommandDistance.cpp \
+	src/mash/CommandTaxScreen.cpp \
 	src/mash/CommandScreen.cpp \
 	src/mash/CommandTriangle.cpp \
 	src/mash/CommandFind.cpp \

--- a/src/mash/CommandTaxScreen.cpp
+++ b/src/mash/CommandTaxScreen.cpp
@@ -1,0 +1,486 @@
+// Copyright © 2015, Battelle National Biodefense Institute (BNBI);
+// all rights reserved. Authored by: Brian Ondov, Todd Treangen,
+// Sergey Koren, and Adam Phillippy
+//
+// See the LICENSE.txt file included with this software for license information.
+
+#include "CommandTaxScreen.h"
+#include "CommandDistance.h" // for pvalue
+#include "Sketch.h"
+#include "kseq.h"
+#include "taxdb.hpp"
+#include <iostream>
+#include <zlib.h>
+#include "ThreadPool.h"
+#include <math.h>
+#include <set>
+
+#ifdef USE_BOOST
+	#include <boost/math/distributions/binomial.hpp>
+	using namespace::boost::math;
+#else
+	#include <gsl/gsl_cdf.h>
+#endif
+
+#define SET_BINARY_MODE(file)
+KSEQ_INIT(gzFile, gzread)
+
+using std::ifstream;
+using std::stringstream;
+
+namespace mash {
+
+inline bool file_exists (const std::string& name) {
+    ifstream f(name.c_str());
+    return f.good();
+}
+
+
+CommandTaxScreen::CommandTaxScreen()
+: Command()
+{
+	name = "taxscreen";
+	summary = "Create Kraken-style taxonomic report based on mash screen.";
+	description = "Create Kraken-style taxonomic report based on how well query sequences are contained within a pool of sequences. The queries must be formatted as a single Mash sketch file (.msh), created with the `mash sketch` command. The <pool> files can be contigs or reads, in fasta or fastq, gzipped or not, and \"-\" can be given for <pool> to read from standard input. The <pool> sequences are assumed to be nucleotides, and will be 6-frame translated if the <queries> are amino acids. The output fields are [total percent of hashes, number of contained hashes in the clade, number of contained hashes in the taxon, total number of hashes in the clade, total number of hashes in the taxon, rank, taxonomy ID, padded name].";
+    argumentString = "<queries>.msh <pool> [<pool>] ...";
+
+	useOption("help");
+	useOption("threads");
+//	useOption("minCov");
+//    addOption("saturation", Option(Option::Boolean, "s", "", "Include saturation curve in output. Each line will have an additional field representing the absolute number of k-mers seen at each Jaccard increase, formatted as a comma-separated list.", ""));
+    addOption("identity", Option(Option::Number, "i", "Output", "Minimum identity to report. Inclusive unless set to zero, in which case only identities greater than zero (i.e. with at least one shared hash) will be reported. Set to -1 to output everything.", "0", -1., 1.));
+    addOption("pvalue", Option(Option::Number, "v", "Output", "Maximum p-value to report.", "1.0", 0., 1.));
+	addOption("mapping-file", Option(Option::String, "m", "", "Mapping file from reference name to taxonomy ID", ""));
+	addOption("taxonomy-dir", Option(Option::String, "t", "", "Directory containing NCBI taxonomy dump", "."));
+}
+
+int CommandTaxScreen::run() const
+{
+	if ( arguments.size() < 2 || options.at("help").active )
+	{
+		print();
+		return 0;
+	}
+
+	if ( ! hasSuffix(arguments[0], suffixSketch) )
+	{
+		cerr << "ERROR: " << arguments[0] << " does not look like a sketch (.msh)" << endl;
+		exit(1);
+	}
+
+	bool sat = false;//options.at("saturation").active;
+
+    double pValueMax = options.at("pvalue").getArgumentAsNumber();
+    double identityMin = options.at("identity").getArgumentAsNumber();
+    string taxonomyDir = options.at("taxonomy-dir").argument;
+    string mappingFileName = options.at("mapping-file").argument;
+
+    vector<string> refArgVector;
+    refArgVector.push_back(arguments[0]);
+
+	Sketch sketch;
+    Sketch::Parameters parameters;
+
+    sketch.initFromFiles(refArgVector, parameters);
+
+    string alphabet;
+    sketch.getAlphabetAsString(alphabet);
+    setAlphabetFromString(parameters, alphabet.c_str());
+
+	parameters.parallelism = options.at("threads").getArgumentAsNumber();
+	parameters.kmerSize = sketch.getKmerSize();
+	parameters.noncanonical = sketch.getNoncanonical();
+	parameters.use64 = sketch.getUse64();
+	parameters.preserveCase = sketch.getPreserveCase();
+	parameters.seed = sketch.getHashSeed();
+	parameters.minHashesPerWindow = sketch.getMinHashesPerWindow();
+
+	HashTable hashTable;
+	unordered_map<uint64_t, std::atomic<uint32_t>> hashCounts;
+	unordered_map<uint64_t, TaxID> hashTaxIDs;
+	unordered_map<uint64_t, list<uint32_t> > saturationByIndex;
+
+	string namesDumpFile = taxonomyDir + "/names.dmp";
+	string nodesDumpFile = taxonomyDir + "/nodes.dmp";
+	if (!file_exists(namesDumpFile) || !file_exists(nodesDumpFile)) {
+		cerr << "Could not find a file names.dmp or nodes.dmp in directory " << taxonomyDir << "\n" 
+		     << " To download the required taxonomy files into the current directory, use the following commands:\n"
+			 << "   wget ftp://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz\n"
+			 << "   tar xvvf taxdump.tar.gz\n"
+			 << endl;
+		exit(1);
+
+	}
+	cerr << "Loading taxonomy files ..." << endl;
+	TaxDB taxdb(namesDumpFile, nodesDumpFile); 
+
+	cerr << "Reading mapping file ..." << endl;
+	// Read mapping file - not implemented in favor of specifying the taxonomy ID in the reference comment
+	vector<TaxID> referenceTaxIDs(sketch.getReferenceCount(), 0);
+	if (mappingFileName != "") {
+	  	std::ifstream mappingFile(mappingFileName);
+	  	if (!mappingFile.is_open())
+	    	throw std::runtime_error("unable to open mapping file");
+
+		string referenceID;
+		TaxID taxID;
+		unordered_map<string, TaxID> refTaxMap;
+	  	while (mappingFile >> taxID) 
+		{
+			mappingFile.ignore(1);
+			getline(mappingFile, referenceID, '\n');
+			refTaxMap.emplace(referenceID, taxID);
+	  	}
+		for ( int i = 0; i < sketch.getReferenceCount(); i ++ )
+		{
+			auto const it = refTaxMap.find(sketch.getReference(i).name);
+			if (it == refTaxMap.end()) {
+				// No warning? Could still be mapped based on comment
+				//cerr << "Could not find taxID for reference " << sketch.getReference(i).name << endl;
+			} else {
+				referenceTaxIDs[i] = it->second;
+			}
+		}	
+	} 
+	for ( int i = 0; i < sketch.getReferenceCount(); i ++ )
+	{
+		string word;
+		TaxID taxID = referenceTaxIDs[i];
+		if (taxID == 0) 
+		{
+			stringstream comment_stream(sketch.getReference(i).comment);
+			while (comment_stream >> word) {
+				if (word == "taxid") {
+					comment_stream >> taxID;
+				}
+			}
+		}
+		if (taxID == 0) {
+			cerr << "Could not find taxID for reference " << sketch.getReference(i).name << " in comment field or mapping file!" << endl;
+		} else {
+			//cerr << "Got taxID " << taxID << " for reference " << sketch.getReference(i).name << endl;
+			referenceTaxIDs[i] = taxID;
+		}
+	}
+	
+
+	cerr << "Loading " << arguments[0] << "..." << endl;
+
+	// for each reference
+	for ( int i = 0; i < sketch.getReferenceCount(); i++ )
+	{
+		const HashList & hashes = sketch.getReference(i).hashesSorted;
+
+        // for each hash a reference has
+		for ( int j = 0; j < hashes.size(); j++ )
+		{
+			uint64_t hash = hashes.get64() ? hashes.at(j).hash64 : hashes.at(j).hash32;
+
+			if ( hashTable.count(hash) == 0 )
+			{
+			    // records the counts for each hash
+				hashCounts[hash] = 0;
+			}
+
+			// save the reference ID for the hash
+			hashTable[hash].insert(i);
+		}
+	}
+
+	cerr << "   " << hashTable.size() << " distinct hashes." << endl;
+
+	unordered_set<MinHashHeap *> minHashHeaps;
+
+	bool trans = (alphabet == alphabetProtein);
+
+/*	if ( ! trans )
+	{
+		if ( alphabet != alphabetNucleotide )
+		{
+			cerr << "ERROR: <query> sketch must have nucleotide or amino acid alphabet" << endl;
+			exit(1);
+		}
+
+		if ( sketch.getNoncanonical() )
+		{
+			cerr << "ERROR: nucleotide <query> sketch must be canonical" << endl;
+			exit(1);
+		}
+	}
+*/
+
+	int queryCount = arguments.size() - 1;
+	cerr << (trans ? "Translating from " : "Streaming from ");
+
+	if ( queryCount == 1 )
+	{
+		cerr << arguments[1];
+	}
+	else
+	{
+		cerr << queryCount << " inputs";
+	}
+
+	cerr << "..." << endl;
+
+	int kmerSize = parameters.kmerSize;
+	int minCov = 1;//options.at("minCov").getArgumentAsNumber();
+
+	ThreadPool<CommandScreen::HashInput, CommandScreen::HashOutput> threadPool(hashSequence, parameters.parallelism);
+
+	// open all query files for round robin
+	//
+	gzFile fps[queryCount];
+	list<kseq_t *> kseqs;
+	//
+	for ( int f = 1; f < arguments.size(); f++ )
+	{
+		if ( arguments[f] == "-" )
+		{
+			if ( f > 1 )
+			{
+				cerr << "ERROR: '-' for stdin must be first query" << endl;
+				exit(1);
+			}
+
+			fps[f - 1] = gzdopen(fileno(stdin), "r");
+		}
+		else
+		{
+			fps[f - 1] = gzopen(arguments[f].c_str(), "r");
+
+			if ( fps[f - 1] == 0 )
+			{
+				cerr << "ERROR: could not open " << arguments[f] << endl;
+				exit(1);
+			}
+		}
+
+		kseqs.push_back(kseq_init(fps[f - 1]));
+	}
+
+	// perform round-robin, closing files as they end
+
+	int l;
+	uint64_t count = 0;
+	//uint64_t kmersTotal = 0;
+	uint64_t chunkSize = 1 << 20;
+	string input;
+	input.reserve(chunkSize);
+	list<kseq_t *>::iterator it = kseqs.begin();
+	//
+	while ( true )
+	{
+		if ( kseqs.begin() == kseqs.end() )
+		{
+			l = 0;
+		}
+		else
+		{
+			l = kseq_read(*it);
+
+			if ( l < -1 ) // error
+			{
+				break;
+			}
+
+			if ( l == -1 ) // eof
+			{
+				kseq_destroy(*it);
+				it = kseqs.erase(it);
+				if ( it == kseqs.end() )
+				{
+					it = kseqs.begin();
+				}
+				//continue;
+			}
+		}
+
+		if ( input.length() + (l >= kmerSize ? l + 1 : 0) > chunkSize || kseqs.begin() == kseqs.end() )
+		{
+			// chunk big enough or at the end; time to flush
+
+			// buffer this out since kseq will overwrite (deleted by HashInput destructor)
+			//
+			char * seqCopy = new char[input.length()];
+			//
+			memcpy(seqCopy, input.c_str(), input.length());
+
+			if ( minHashHeaps.begin() == minHashHeaps.end() )
+			{
+				minHashHeaps.emplace(new MinHashHeap(sketch.getUse64(), sketch.getMinHashesPerWindow()));
+			}
+
+			threadPool.runWhenThreadAvailable(new CommandScreen::HashInput(hashCounts, *minHashHeaps.begin(), seqCopy, input.length(), parameters, trans));
+
+			input = "";
+
+			minHashHeaps.erase(minHashHeaps.begin());
+
+			while ( threadPool.outputAvailable() )
+			{
+				useThreadOutput(threadPool.popOutputWhenAvailable(), minHashHeaps);
+			}
+		}
+
+		if ( kseqs.begin() == kseqs.end() )
+		{
+			break;
+		}
+
+		count++;
+
+		if ( l >= kmerSize )
+		{
+			input.append(1, '*');
+			input.append((*it)->seq.s, l);
+		}
+
+		it++;
+
+		if ( it == kseqs.end() )
+		{
+			it = kseqs.begin();
+		}
+	}
+
+	if (  l != -1 )
+	{
+		cerr << "\nERROR: reading inputs" << endl;
+		exit(1);
+	}
+
+	while ( threadPool.running() )
+	{
+		useThreadOutput(threadPool.popOutputWhenAvailable(), minHashHeaps);
+	}
+
+	for ( int i = 0; i < queryCount; i++ )
+	{
+		gzclose(fps[i]);
+	}
+
+	MinHashHeap minHashHeap(sketch.getUse64(), sketch.getMinHashesPerWindow());
+
+	for ( unordered_set<MinHashHeap *>::const_iterator i = minHashHeaps.begin(); i != minHashHeaps.end(); i++ )
+	{
+		HashList hashList(parameters.use64);
+
+		(*i)->toHashList(hashList);
+
+		for ( int i = 0; i < hashList.size(); i++ )
+		{
+			minHashHeap.tryInsert(hashList.at(i));
+		}
+
+		delete *i;
+	}
+
+	if ( count == 0 )
+	{
+		cerr << "\nERROR: Did not find sequence records in inputs" << endl;
+
+		exit(1);
+	}
+
+	/*
+	if ( parameters.targetCov != 0 )
+	{
+		cerr << "Reads required for " << parameters.targetCov << "x coverage: " << count << endl;
+	}
+	else
+	{
+		cerr << "Estimated coverage: " << minHashHeap.estimateMultiplicity() << "x" << endl;
+	}
+	*/
+
+	uint64_t setSize = minHashHeap.estimateSetSize();
+	cerr << "   Estimated distinct" << (trans ? " (translated)" : "") << " k-mers in pool: " << setSize << endl;
+
+	if ( setSize == 0 )
+	{
+		cerr << "WARNING: no valid k-mers in input." << endl;
+		//exit(0);
+	}
+
+    // for each hash we can calculate the LCA, and add a count to the LCA at the end
+	cerr << "Assigning LCA taxIDs to hashes ..." << endl;
+
+	uint64_t * shared = new uint64_t[sketch.getReferenceCount()]; // number of hashes shared with the query
+	vector<uint64_t> * depths = new vector<uint64_t>[sketch.getReferenceCount()]; // how many other references share each hash of a reference?
+	memset(shared, 0, sizeof(uint64_t) * sketch.getReferenceCount());
+	unordered_map<TaxID, TaxCounts> counts;
+	unordered_set<TaxID> allTaxIDs;
+
+	for ( unordered_map<uint64_t, std::atomic<uint32_t> >::const_iterator i = hashCounts.begin(); i != hashCounts.end(); i++ )
+	{
+		// indices of all the references - map them to taxonomy IDs
+		const unordered_set<uint64_t> & indeces = hashTable.at(i->first);
+
+		TaxID taxID = 0;
+		for ( unordered_set<uint64_t>::const_iterator k = indeces.begin(); k != indeces.end(); k++ )
+		{
+			taxID = taxdb.getLowestCommonAncestor(referenceTaxIDs[*k], taxID);
+			shared[*k]++;
+			depths[*k].push_back(i->second);
+
+			if ( sat )
+			{
+				saturationByIndex[*k].push_back(0);// TODO kmersTotal);
+			}
+		}
+		//hashTaxIDs.insert(i->first, taxID);
+		hashTaxIDs[i->first] = taxID;
+		counts[taxID].taxHashCount += 1;
+		if ( i->second >= minCov )
+		{
+			counts[taxID].taxCount += 1;
+		allTaxIDs.insert(taxID);
+		}
+	}
+
+	// Sum up the clade counts and populate the children vectors
+	uint64_t totalCount = 0;
+	uint64_t totalHashCount = 0;
+	for ( unordered_map<TaxID, TaxCounts>::iterator it = counts.begin(); it != counts.end(); ++it ) 
+	{
+		uint64_t hashCount = it->second.taxHashCount;
+		totalHashCount += hashCount;
+
+		uint64_t count = it->second.taxCount;
+		totalCount += count;
+
+		TaxID taxID = it->first;
+		TaxEntry const * taxon = taxdb.getEntry(taxID);
+		while (taxon != NULL) {
+			counts[taxon->taxID].cladeCount += count;
+			counts[taxon->taxID].cladeHashCount += hashCount;
+			if (taxon->parent != NULL) {
+				vector<TaxID>& children = counts[taxon->parent->taxID].children;
+				auto pc_it = lower_bound(children.begin(),
+				                         children.end(),
+									     taxon->taxID);
+				if (pc_it == children.end() || *pc_it != taxon->taxID) {
+					children.insert(pc_it, taxon->taxID);
+				}
+				taxon = taxon->parent;
+			} else {
+				break;
+			}
+		}
+	}
+
+	cerr << "Writing output..." << endl;
+
+	taxdb.writeReport(stdout, counts, totalCount, totalHashCount);
+
+	delete [] shared;
+
+	return 0;
+}
+
+
+
+
+
+} // namespace mash

--- a/src/mash/CommandTaxScreen.h
+++ b/src/mash/CommandTaxScreen.h
@@ -1,0 +1,62 @@
+// Copyright © 2015, Battelle National Biodefense Institute (BNBI);
+// all rights reserved. Authored by: Brian Ondov, Todd Treangen,
+// Sergey Koren, and Adam Phillippy
+//
+// See the LICENSE.txt file included with this software for license information.
+
+#ifndef INCLUDED_CommandTaxScreen
+#define INCLUDED_CommandTaxScreen
+
+#include "Command.h"
+#include "Sketch.h"
+#include <list>
+#include <string>
+#include <vector>
+#include <atomic>
+#include <unordered_set>
+#include <unordered_map>
+#include "MinHashHeap.h"
+#include "CommandScreen.h"
+
+
+using std::string;
+using std::cerr;
+using std::cout;
+using std::endl;
+using std::list;
+using std::string;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+
+
+namespace mash {
+
+using TaxID = uint64_t;
+
+typedef std::unordered_map< uint64_t, std::unordered_set<uint64_t> > HashTable;
+
+class CommandTaxScreen : public Command
+{
+public:
+    
+    CommandTaxScreen();
+    
+    int run() const; // override
+
+private:
+	
+	struct Reference
+	{
+		Reference(uint64_t amerCountNew, std::string nameNew, std::string commentNew)
+		: amerCount(amerCountNew), name(nameNew), comment(commentNew) {}
+		
+		uint64_t amerCount;
+		std::string name;
+		std::string comment;
+	};
+};
+
+} // namespace mash
+
+#endif

--- a/src/mash/mash.cpp
+++ b/src/mash/mash.cpp
@@ -10,6 +10,7 @@
 #include "CommandFind.h"
 #include "CommandDistance.h"
 #include "CommandScreen.h"
+#include "CommandTaxScreen.h"
 #include "CommandTriangle.h"
 #include "CommandContain.h"
 #include "CommandInfo.h"
@@ -23,6 +24,7 @@ int main(int argc, const char ** argv)
     //commandList.addCommand(new CommandFind());
     commandList.addCommand(new mash::CommandDistance());
     commandList.addCommand(new mash::CommandScreen());
+    commandList.addCommand(new mash::CommandTaxScreen());
     commandList.addCommand(new mash::CommandTriangle());
 #ifdef COMMAND_WITHIN
     commandList.addCommand(new mash::CommandContain());

--- a/src/mash/taxdb.hpp
+++ b/src/mash/taxdb.hpp
@@ -1,0 +1,304 @@
+#ifndef TAXD_DB_H_
+#define TAXD_DB_H_
+
+// Florian Breitiweser
+
+#include <algorithm>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+#include <unordered_set>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+
+
+using TaxID = uint64_t;
+
+using std::vector;
+using std::string;
+
+namespace mash {
+
+class TaxEntry {
+  public:
+    TaxID taxID;
+    TaxEntry* parent;
+    vector<TaxEntry*> children;
+
+    string rank;
+    string name; // scientific name
+
+    TaxEntry() : taxID(0), parent(NULL) {}
+
+    TaxEntry(TaxID taxID, string rank) : taxID(taxID), rank(rank) {}
+};
+
+struct TaxCounts {
+  uint64_t cladeCount = 0;
+  uint64_t taxCount = 0;
+  uint64_t taxHashCount = 0;
+  uint64_t cladeHashCount = 0;
+  vector<TaxID> children;
+};
+
+class TaxDB {
+  public:
+    TaxDB(const string namesDumpFileName, const string nodesDumpFileName);
+    TaxDB(const string inFileName);
+    TaxDB();
+
+    void writeTaxIndex(std::ostream & outs) const;
+    void readTaxIndex(const string inFileName);
+
+    TaxID getLowestCommonAncestor(TaxID a, TaxID b) const;
+    string getLineage(TaxID taxID) const;
+    string getMetaPhlAnLineage(TaxID taxID) const;
+    TaxEntry const * getEntry(TaxID taxID) const;
+
+    unordered_map<TaxID, TaxEntry> entries;
+
+    void writeReport(FILE* FP, const unordered_map<TaxID, TaxCounts> & counts, 
+                     unsigned long totalCounts, 
+                     unsigned long totalHashCounts, 
+                     TaxID taxID = 0, int depth = 0);
+
+  private:
+    unordered_map<TaxEntry*, TaxID> parseNodesDump(const string nodesDumpFile);
+    void parseNamesDump(const string namesDumpFile);
+};
+
+TaxEntry const * TaxDB::getEntry(TaxID taxID) const {
+  auto it = entries.find(taxID);
+  if (it == entries.end()) {
+    cerr << "Couldn't find tax entry with taxID " << taxID << endl;
+    return NULL;
+  } else {
+    return &it->second;
+  }
+}
+
+
+TaxDB::TaxDB(const string namesDumpFileName, const string nodesDumpFileName) {
+  unordered_map<TaxEntry*, TaxID> parentMap = parseNodesDump(nodesDumpFileName);
+
+  // set parent links correctly
+  for (auto const & c : parentMap) {
+    if (c.first->taxID != c.second) {
+      auto p = entries.find(c.second);
+      if (p == entries.end()) {
+         cerr << "Could not find parent with tax ID " << c.second << " for tax ID " << c.first->taxID << endl;
+      } else {
+        c.first->parent = &p->second;
+      }
+    } else {
+      c.first->parent = NULL;
+    }
+  }
+  parseNamesDump(namesDumpFileName);
+  cerr << "   " << entries.size() << " distinct taxa\n";
+}
+
+unordered_map<TaxEntry*,TaxID> TaxDB::parseNodesDump(const string nodesDumpFileName) {
+  std::ifstream nodesDumpFile(nodesDumpFileName);
+  if (!nodesDumpFile.is_open())
+    throw std::runtime_error("unable to open nodes file");
+
+  string line;
+  TaxID taxID;
+  TaxID parentTaxID;
+  string rank;
+  char delim;
+  unordered_map<TaxEntry*,TaxID> parentMap;
+
+  while (nodesDumpFile >> taxID >> delim >> parentTaxID >> delim) {
+    nodesDumpFile.ignore(1);
+    getline(nodesDumpFile, rank, '\t');
+    // TODO: Insert
+    //auto res = entries.insert(taxID, TaxEntry(taxID, rank));
+    auto res = entries.emplace(taxID, TaxEntry(taxID, rank));
+    parentMap.emplace(&res.first->second, parentTaxID);
+    nodesDumpFile.ignore(2560, '\n');
+  }
+  return parentMap;
+}
+
+void TaxDB::parseNamesDump(const string namesDumpFileName) {
+  std::ifstream namesDumpFile(namesDumpFileName);
+  if (!namesDumpFile.is_open())
+    throw std::runtime_error("unable to open names file");
+  string line;
+
+  TaxID taxID;
+  string name, type;
+  char delim;
+  while (namesDumpFile >> taxID) {
+    namesDumpFile.ignore(3);
+    getline(namesDumpFile, name, '\t');
+    namesDumpFile.ignore(3);
+    namesDumpFile.ignore(256, '|');
+    namesDumpFile.ignore(1);
+    getline(namesDumpFile, type, '\t');
+
+    if (type == "scientific name") {
+      auto entryIt = entries.find(taxID);
+      if (entryIt == entries.end()) {
+        cerr << "Entry for " << taxID << " does not exist - it should!" << '\n';
+      } else {
+        entryIt->second.name = name;
+      }
+    }
+    namesDumpFile.ignore(2560, '\n');
+  }
+}
+
+TaxID TaxDB::getLowestCommonAncestor(TaxID a, TaxID b) const {
+  if (b == 0) { return a; }
+  if (a == 0) { return b; } 
+
+  // create a path from a to the root
+  unordered_set<TaxEntry const *> a_path;
+  std::unordered_map<TaxID, TaxEntry>::const_iterator ta = entries.find(a);
+  if (ta == entries.end()) {
+    cerr << "TaxID " << a << " not in database - ignoring it.\n";
+    return 1;
+  }
+
+  std::unordered_map<TaxID, TaxEntry>::const_iterator tb = entries.find(b);
+  if (tb == entries.end()) {
+    cerr << "TaxID " << b << " not in database - ignoring it.\n";
+    return 1;
+  }
+  TaxEntry const * pta = &(ta->second);
+  while (pta != NULL && pta->taxID > 1 && pta->parent != NULL) {
+    if (pta->taxID == b) { return b; }
+    a_path.insert(pta);
+    pta = pta->parent;
+  }
+  TaxEntry const * ptb = &(tb->second);
+  // search for b in the path from a to the root
+  while (ptb->taxID > 0 && ptb->parent != NULL) {
+    if (a_path.count(ptb)) {
+      return ptb->taxID;
+    }
+    ptb = ptb->parent;
+  }
+  return 1;
+}
+
+void TaxDB::writeReport(FILE* FP,
+			const unordered_map<TaxID, TaxCounts> & counts,
+			unsigned long totalCounts,
+			unsigned long totalHashCounts,
+			TaxID taxID, int depth) {
+
+	unordered_map<TaxID, TaxCounts>::const_iterator it = counts.find(taxID);
+	unsigned int cladeCount = it == counts.end()? 0 : it->second.cladeCount;
+	unsigned int cladeHashCount = it == counts.end()? 0 : it->second.cladeHashCount;
+	unsigned int taxCount = it == counts.end()? 0 : it->second.taxCount;
+	unsigned int taxHashCount = it == counts.end()? 0 : it->second.taxHashCount;
+	if (taxID == 0) {
+    // TODO: Write header?
+    // identity, shared-hashes, median-multiplicity, p-value, query-ID, query-comment
+    fprintf(FP, "%%\thashes\ttaxHashes\thashesDB\ttaxHashesDB\ttaxID\trank\tname\n");
+		if (cladeCount > 0) { // Should not happen
+			fprintf(FP, "%.4f\t%i\t%i\tno rank\t0\tunclassified\n",
+					100 * cladeCount / double(totalCounts),
+					cladeCount, taxCount);
+		}
+	  writeReport(FP, counts, totalCounts, totalHashCounts, 1, 0);
+	} else {
+		if (cladeCount == 0) {
+			return;
+		}
+		TaxEntry const * taxon = getEntry(taxID);
+		fprintf(FP, "%.4f\t%i\t%i\t%i\t%i\t%s\t%llu\t%s%s\n",
+				100*cladeCount/double(totalCounts), 
+        cladeCount, 
+        taxCount, 
+        cladeHashCount,
+        taxHashCount,
+				taxon->rank.c_str(), taxID, std::string(2*depth, ' ').c_str(), taxon->name.c_str());
+
+		std::vector<TaxID> children = it->second.children;
+		std::sort(children.begin(), children.end(), [&](int a, int b) { return counts.at(a).cladeCount > counts.at(b).cladeCount; });
+		for (TaxID childTaxId : children) {
+			if (counts.count(childTaxId)) {
+				writeReport(FP, counts, totalCounts, totalHashCounts, childTaxId, depth + 1);
+			} else {
+				break;
+			}
+		}
+	}
+}
+
+/*
+string TaxDB::getLineage(TaxEntry tax) const {
+  string lineage;
+  while (true) {
+    // 131567 = Cellular organisms
+    if (taxID != 131567) {
+      if (lineage.size()) lineage.insert(0, "; ");
+      lineage.insert(0, getScientificName(taxID));
+      if (getRank(taxID) == "species") lineage.clear();
+    }
+    taxID = getParentTaxID(taxID);
+    if (taxID == 0) {
+      if (lineage.size()) lineage.append(".");
+      break;
+    }
+  }
+  return lineage;
+}
+
+string TaxDB::getMetaPhlAnLineage(TaxID taxID) const {
+  string rank = getRank(taxID);
+  if (rank == "superphylum") return string();
+  string lineage;
+  while (true) {
+    // 131567 = Cellular organisms
+    //if (taxID != 131567) {
+      string rank = getRank(taxID);
+      if (rank == "species") {
+  lineage.insert(0, "|s__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "genus") {
+  lineage.insert(0, "|g__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "family") {
+  lineage.insert(0, "|f__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "order") {
+  lineage.insert(0, "|o__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "class") {
+  lineage.insert(0, "|c__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "phylum") {
+  lineage.insert(0, "|p__");
+  lineage.insert(4, getScientificName(taxID));
+      } else if (rank == "superkingdom") {
+  lineage.insert(0, "|k__");
+  lineage.insert(4, getScientificName(taxID));
+      } else {
+  lineage.insert(0, "|-__");
+  lineage.insert(4, getScientificName(taxID));
+
+	 // }
+    }
+    taxID = getParentTaxID(taxID);
+    if (taxID == 0) {
+      break;
+    }
+  }
+  std::replace(lineage.begin(), lineage.end(), ' ', '_');
+  return lineage;
+}
+*/
+
+}
+
+#endif /* TAXD_DB_H_ */


### PR DESCRIPTION
Adding this pull request for discussion. This adds a command taxscreen to mash, which outputs a Kraken-style taxonomic report. For this, it loads the NCBI taxonomy files `nodes.dmp` and `names.dmp`  from a folder specified with `-t` (default `.`). To map the mash references to taxonomy IDs, either the taxonomy ID has to be encoded in the comment field of each reference (`taxid XXXX`), or a mapping file has to be supplied (option `-m`, not well tested yet).

A companion genome download and sketching script is at https://github.com/fbreitwieser/taxmash. This creates mash sketches with references with rich ID and comment fields, e. g. ID `GCF_003201835.1 Acidianus brierleyi, CompleteGenome assembly [2.95 Mbp, 1 seqs]`, comment `taxid 41673`).

Currently the output reports the shared hashes at each level in the taxonomic tree specific to one node (`taxHashes/taxHashesDB`) and specific to the node and its children (`hashes/hashesDB`). The names of the columns for sure could be better. `p-value`, `identity` and `median-multiplicity` columns which are reported in `mash screen` could be added, too. 

Example output:
```
$ mash taxscreen archaea.msh archaea-test.msh

%	hashes	taxHashes	hashesDB	taxHashesDB	taxID	rank	name
100.0000	557	0	448901	0	no rank	1	root
100.0000	557	0	448901	0	no rank	131567	  cellular organisms
100.0000	557	3	448901	300	superkingdom	2157	    Archaea
84.5601	471	1	372025	228	phylum	28890	      Euryarchaeota
56.7325	316	0	253546	140	no rank	2290931	        Stenosarchaea group
48.1149	268	38	186986	6523	class	183963	          Halobacteria
24.7756	138	14	71202	1074	order	1644055	            Haloferacales
11.6697	65	9	31337	454	family	1644056	              Haloferacaceae
6.6427	37	18	10148	3304	genus	2251	                Haloferax
1.2567	7	7	799	799	species	1544718	                  Haloferax sp. SB29
0.5386	3	3	55	55	species	2077201	                  Haloferax sp. Atlit-19N
```