### PR TITLE
Fix issue with too many mapped files

### DIFF
--- a/src/mash/Sketch.cpp
+++ b/src/mash/Sketch.cpp
@@ -311,7 +311,7 @@ uint64_t Sketch::initParametersFromCapnp(const char * file)
     {
     	setAlphabetFromString(parameters, alphabetNucleotide);
     }
-	munmap(fd, fileInfo.st_size);
+	munmap(data, fileInfo.st_size);
 	close(fd);
 	
 	try

--- a/src/mash/Sketch.cpp
+++ b/src/mash/Sketch.cpp
@@ -311,6 +311,7 @@ uint64_t Sketch::initParametersFromCapnp(const char * file)
     {
     	setAlphabetFromString(parameters, alphabetNucleotide);
     }
+	munmap(fd, fileInfo.st_size);
 	close(fd);
 	
 	try


### PR DESCRIPTION
When sketching a large number files, the mappings left in place from Sketch::initParametersFromCapnp will overrun the allowed number of mappings and cause mmap to fail. This patch removes the mapping.